### PR TITLE
Fix test for backtrace_get_executable_path() return value.

### DIFF
--- a/fileline.c
+++ b/fileline.c
@@ -93,7 +93,7 @@ fileline_initialize (struct backtrace_state *state,
 	  filename = state->filename;
 	  break;
   case 1:
-    if (backtrace_get_executable_path(buf, sizeof(buf)) == 0)
+    if (backtrace_get_executable_path(buf, sizeof(buf)) == 1)
         filename = buf;
 	  break;
 	case 2:


### PR DESCRIPTION
The docs on backtrace_get_executable_path() state that a return
code of 1 is a success and 0 is a failure, yet fileline_initialize()
had this the other way around.